### PR TITLE
:sparkles: Add alt text to images in amp sites

### DIFF
--- a/template.html.handlebars
+++ b/template.html.handlebars
@@ -298,12 +298,18 @@
                     layout=responsive
                     src="{{.}}"
                     width="{{../report.mediaSize.width}}"
-                    height="{{../report.mediaSize.height}}">
+                    height="{{../report.mediaSize.height}}"
+                    {{#if ../report.media_alt}}
+                    alt="{{../report.media_alt}}"
+                    {{/if}}>
               <noscript>
                 <img class="image noscript"
                     src="{{.}}"
                     width="{{../report.mediaSize.width}}"
                     height="{{../report.mediaSize.height}}"
+                    {{#if ../report.media_alt}}
+                    alt="{{../report.media_alt}}"
+                    {{/if}}
                 />
               </noscript>
             </amp-img>
@@ -363,12 +369,18 @@
                      layout=responsive
                      src="{{media}}"
                      width="{{mediaSize.width}}"
-                     height="{{mediaSize.height}}">
+                     height="{{mediaSize.height}}"
+                     {{#if media_alt}}
+                     alt="{{media_alt}}"
+                     {{/if}}>
               <noscript>
                 <img class="image noscript"
                      src="{{media}}"
                      width="{{mediaSize.width}}"
                      height="{{mediaSize.height}}"
+                     {{#if media_alt}}
+                     alt="{{media_alt}}"
+                     {{/if}}
                 />
               </noscript>
             </amp-img>


### PR DESCRIPTION
Does everyone know if we need to add the alt text to the meta tag img as well? Could not find any clear information about this.